### PR TITLE
Revert "ignore glide lock"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ k8guard-discover
 config.sh
 coverage.out
 output.txt
-glide.lock


### PR DESCRIPTION
Reverts k8guard/k8guard-discover#2

Restored lock so chained dependencies are managed.