### PR TITLE
Civilized Panic to avoid making useless api calls.

### DIFF
--- a/discover/init.go
+++ b/discover/init.go
@@ -18,6 +18,7 @@ var KafkaProducer kafka.KafkaProducer
 
 
 var err error
+// exporting this error to be used to avoid hammering the api if kafka is not there
 var KafkaProducerError error
 
 func init() {

--- a/discover/init.go
+++ b/discover/init.go
@@ -18,13 +18,14 @@ var KafkaProducer kafka.KafkaProducer
 
 
 var err error
-
+var KafkaProducerError error
 
 func init() {
 	Clientset, err = k8s.LoadClientset()
 	Memcached = memcache.New(fmt.Sprintf("%s:11211", lib.Cfg.MemCachedHostname))
 
-	KafkaProducer, err = kafka.NewProducer(kafka.DISCOVER_CLIENTID, lib.Cfg)
+	KafkaProducer, KafkaProducerError = kafka.NewProducer(kafka.DISCOVER_CLIENTID, lib.Cfg)
+
 	// defer KafkaProducer.Close()
 
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,12 @@ func main() {
 	flag.Parse()
 
 	if *kafkaMode {
+
+		if discover.KafkaProducerError != nil {
+			lib.Log.Error("Kafka is not ready, won't make any api calls")
+			panic(discover.KafkaProducerError)
+		}
+
 		var waitGroup sync.WaitGroup
 		waitGroup.Add(5)
 		lib.Log.Info("Starting in Kafka Mode")


### PR DESCRIPTION
being minnesta-nice to the api server.
if there is no kafka service in messaging mode, it is useless to make kubernetes api calls. 